### PR TITLE
Fix for duplicate IP address problem

### DIFF
--- a/glm-cloudbaseinit-setup.ps1.template.dos
+++ b/glm-cloudbaseinit-setup.ps1.template.dos
@@ -74,3 +74,32 @@ If (-Not (Test-Path -Path "C:\DeployTime.txt" -PathType leaf)) {
     $(Get-Date).ToString() | Out-File -FilePath "C:\DeployTime.txt"
 }
 '@ | Out-File -FilePath "C:\Program Files\Cloudbase Solutions\Cloudbase-Init\LocalScripts\DeployTime.ps1"
+
+# Make each VLAN use a fixed MAC address
+{{- if .Connections}}
+  {{- $fabric := ""}}
+  {{- $macnocolon := "" }}
+  {{- range .Connections}}
+    {{/* Get MAC address of 1st .Interface */}}
+    {{- $mac := (index .Interfaces 0).HWAddr }}
+
+    {{/* Convert MAC addr from GLM format d0:67:26:0a:e9:ac to Windows d067260ae9ac format */}}
+    {{- $mac1 := slice $mac 0 2 }}
+    {{- $mac2 := slice $mac 3 5 }}
+    {{- $mac3 := slice $mac 6 8 }}
+    {{- $mac4 := slice $mac 9 11 }}
+    {{- $mac5 := slice $mac 12 14 }}
+    {{- $mac6 := slice $mac 15 17 }}
+    {{- $macnocolon = printf "%s%s%s%s%s%s" $mac1 $mac2 $mac3 $mac4 $mac5 $mac6 }}
+
+    {{/* Use the Name from .Connections */}}
+    {{- $fabric = .Name }}
+
+    {{/* Set the MAC address of each VLAN */}}
+    {{- range .Networks }}
+@'
+Set-NetAdapterAdvancedProperty -Name "{{ $fabric }}.{{ .VID }}" -DisplayName "MAC Address" -DisplayValue "{{ $macnocolon }}"
+'@ | Out-File -Encoding Ascii -Append -FilePath "C:\Program Files\Cloudbase Solutions\Cloudbase-Init\LocalScripts\SetMacAddress.ps1"
+    {{- end }} {{/* end range .Networks */}}
+  {{- end}}  {{/* end range .Connections  */}}
+{{- end}}    {{/* end if .Connections */}}

--- a/glm-cloudbaseinit-setup.ps1.template.dos
+++ b/glm-cloudbaseinit-setup.ps1.template.dos
@@ -27,7 +27,7 @@ username=GreenlakeAdmin
 rename_admin_user=true
 # Services that will be tested for loading until one of them succeeds.
 metadata_services=cloudbaseinit.metadata.services.nocloudservice.NoCloudConfigDriveService
-plugins= cloudbaseinit.plugins.common.networkconfig.NetworkConfigPlugin, cloudbaseinit.plugins.windows.createuser.CreateUserPlugin, cloudbaseinit.plugins.common.mtu.MTUPlugin, cloudbaseinit.plugins.windows.ntpclient.NTPClientPlugin, cloudbaseinit.plugins.common.sethostname.SetHostNamePlugin, cloudbaseinit.plugins.windows.licensing.WindowsLicensingPlugin, cloudbaseinit.plugins.common.sshpublickeys.SetUserSSHPublicKeysPlugin, cloudbaseinit.plugins.windows.winrmlistener.ConfigWinRMListenerPlugin, cloudbaseinit.plugins.common.localscripts.LocalScriptsPlugin
+plugins= cloudbaseinit.plugins.common.networkconfig.NetworkConfigPlugin, cloudbaseinit.plugins.windows.createuser.CreateUserPlugin, cloudbaseinit.plugins.common.mtu.MTUPlugin, cloudbaseinit.plugins.windows.ntpclient.NTPClientPlugin, cloudbaseinit.plugins.common.sethostname.SetHostNamePlugin, cloudbaseinit.plugins.windows.licensing.WindowsLicensingPlugin, cloudbaseinit.plugins.common.sshpublickeys.SetUserSSHPublicKeysPlugin, cloudbaseinit.plugins.windows.winrmlistener.ConfigWinRMListenerPlugin, cloudbaseinit.plugins.common.userdata.UserDataPlugin, cloudbaseinit.plugins.common.localscripts.LocalScriptsPlugin
 
 [config_drive]
 # Which devices to inspect for a possible configuration drive
@@ -95,7 +95,12 @@ If (-Not (Test-Path -Path "C:\DeployTime.txt" -PathType leaf)) {
     {{/* Use the Name from .Connections */}}
     {{- $fabric = .Name }}
 
-    {{/* Set the MAC address of each VLAN */}}
+# Set the MAC address on the Team interface for untagged network
+@'
+Set-NetAdapterAdvancedProperty -Name "{{ $fabric }}" -DisplayName "MAC Address" -DisplayValue "{{ $macnocolon }}"
+'@ | Out-File -Encoding Ascii -Append -FilePath "C:\Program Files\Cloudbase Solutions\Cloudbase-Init\LocalScripts\SetMacAddress.ps1"
+
+# Set the MAC address of each VLAN tagged network
     {{- range .Networks }}
 @'
 Set-NetAdapterAdvancedProperty -Name "{{ $fabric }}.{{ .VID }}" -DisplayName "MAC Address" -DisplayValue "{{ $macnocolon }}"
@@ -103,3 +108,10 @@ Set-NetAdapterAdvancedProperty -Name "{{ $fabric }}.{{ .VID }}" -DisplayName "MA
     {{- end }} {{/* end range .Networks */}}
   {{- end}}  {{/* end range .Connections  */}}
 {{- end}}    {{/* end if .Connections */}}
+
+# Setting the CloudBase-Init service to Disabled so it will not run on future boots and reset settings that were
+# manually configured after boot, such as manually reset GreenlakeAdmin password
+@'
+Set-Service -Name cloudbase-init -StartupType Disabled
+'@ | Out-File -FilePath "C:\Program Files\Cloudbase Solutions\Cloudbase-Init\LocalScripts\DisableCloudBaseInit.ps1"
+

--- a/glm-user-data.template.dos
+++ b/glm-user-data.template.dos
@@ -6,6 +6,7 @@
 {{- if .SSHKeys }}
 users:
   - name: GreenLakeAdmin
+    passwd: CLEARTEXTPASSWORD
     ssh_authorized_keys:
   {{- range $key := .SSHKeys}}
       - {{$key }}


### PR DESCRIPTION
As part of cloudbase-init setup script, create a script.("C:\Program Files\Cloudbase Solutions\Cloudbase-Init\LocalScripts\SetMacAddress.ps1") that makes sure that each VLAN gets a fixed MAC address so that it eliminately duplicate IP address problems.