### PR TITLE
Revert "Undo No-IPPool changes until PROD portal picks up the required backend support"

### DIFF
--- a/Modules/Yaml.ps1
+++ b/Modules/Yaml.ps1
@@ -67,49 +67,49 @@ files:
 info:
   - encoding: base64
     templating: go-text-template
-    templating_input: hostdef-v3
+    templating_input: hostdef-v4
     target: vmedia-floppy
     path: /Autounattend.xml
     contents: $([System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$CurrentPath/Autounattend.xml")))
   - encoding: base64
     templating: go-text-template
-    templating_input: hostdef-v3
+    templating_input: hostdef-v4
     target: vmedia-floppy
     path: /cloudbaseinit-setup.ps1
     contents: $([System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$CurrentPath/glm-cloudbaseinit-setup.ps1.template.dos")))
   - encoding: base64
     templating: go-text-template
-    templating_input: hostdef-v3
+    templating_input: hostdef-v4
     target: vmedia-floppy
     path: /windowsexporter-setup.ps1
     contents: $([System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$CurrentPath/glm-windowsexporter-setup.ps1.template.dos")))
   - encoding: base64
     templating: go-text-template
-    templating_input: hostdef-v3
+    templating_input: hostdef-v4
     target: vmedia-floppy
     path: /meta-data
     contents: $([System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$CurrentPath/glm-meta-data.template.dos")))
   - encoding: base64
     templating: go-text-template
-    templating_input: hostdef-v3
+    templating_input: hostdef-v4
     target: vmedia-floppy
     path: /network-config
     contents: $([System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$CurrentPath/glm-network-config.template.dos")))
   - encoding: base64
     templating: go-text-template
-    templating_input: hostdef-v3
+    templating_input: hostdef-v4
     target: vmedia-floppy
     path: /user-data
     contents: $([System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$CurrentPath/glm-user-data.template.dos")))
   - encoding: base64
     templating: go-text-template
-    templating_input: hostdef-v3
+    templating_input: hostdef-v4
     target: vmedia-floppy
     path: /SetupComplete.cmd
     contents: $([System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$CurrentPath/SetupComplete.cmd")))
   - encoding: base64
     templating: go-text-template
-    templating_input: hostdef-v3
+    templating_input: hostdef-v4
     target: vmedia-floppy
     path: /glm_finisher.ps1
     contents: $([System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$CurrentPath/glm_finisher.ps1.template.dos")))

--- a/glm-network-config.template.dos
+++ b/glm-network-config.template.dos
@@ -24,7 +24,7 @@ config:
       bond-lacp-rate: false
       {{- $vlan_parent = .Name}}
 
-  {{- if gt .UntaggedNet.VID 0 }}
+  {{- if and (gt .UntaggedNet.VID 0) (eq .UntaggedNet.NoIPAddr false) }}
       {{- $net_zero := .UntaggedNet }}
       {{- $range_zero := index $net_zero.Ranges 0 }}
     subnets:
@@ -48,6 +48,7 @@ config:
     name: "{{$vlan_parent}}.{{.VID}}"
     vlan_link:  {{$vlan_parent}}
     vlan_id: {{.VID}}
+      {{- if eq .NoIPAddr false }}
       {{- $range_zero := index .Ranges 0}}
     subnets:
     - type: static
@@ -63,6 +64,7 @@ config:
             {{- end}}
           {{- end}}
         {{- end}}
+      {{- end}}  {{/* if eq .NoIPAddr false */}}
     {{- end}}  {{/* range .Networks */}}
   {{- end}}  {{/* if gt (len .Networks) 0 */}}
   {{- end}}  {{/* range .Connections  */}}


### PR DESCRIPTION
Reverts HewlettPackard/hpegl-metal-os-windows-iso#20
PROD portal (v0.24.336) has hostdef-v4 support now, so undoing the revert.